### PR TITLE
refactor api for new db schema

### DIFF
--- a/src/pages/buy-carts/api/route.ts
+++ b/src/pages/buy-carts/api/route.ts
@@ -6,8 +6,7 @@ import { NextResponse } from "next/server";
 
 export async function GET() {
   const ordersAll = await db.select().from(orders);
-  console.log(ordersAll);
-  const usersId = ordersAll.map((order) => order.userId);
+  const usersId = ordersAll.map((order) => order.user);
 
   const userItemsById = await db
     .select()
@@ -24,12 +23,12 @@ export async function GET() {
     return date.toLocaleString("ru", options);
   }
   const orderFull = ordersAll.map((item) => {
-    const user = userItemsById.find((userItem) => userItem.id === item.userId);
+    const user = userItemsById.find((userItem) => userItem.id === item.user);
     return {
       id: item.id,
-      total: item.total,
+      total: item.price,
       user: user,
-      createdAt: getDate(item.createdAt),
+      createdAt: getDate(item.createAt),
       status: item.status,
     };
   });

--- a/src/pages/cabinet/api/changeInfo.ts
+++ b/src/pages/cabinet/api/changeInfo.ts
@@ -19,7 +19,7 @@ export async function changeInfo(prevState, data) {
     await db
       .update(users)
       .set({
-        name: dataName,
+        firstName: dataName,
         lastName: dataLastName,
         email: dataEmail,
         phone: dataPhone,

--- a/src/pages/cabinet/api/changeStatus.ts
+++ b/src/pages/cabinet/api/changeStatus.ts
@@ -7,7 +7,7 @@ import { sendSalesMessageTelegram } from "@/src/shared/api/telegram/telegram-sal
 export async function approveDeliver(orderId: string): Promise<void> {
   await db
     .update(orders)
-    .set({ status: "DELIVERED" })
+    .set({ status: "delivered" })
     .where(eq(orders.id, orderId));
   const changedOrder = await db
     .select()
@@ -16,15 +16,15 @@ export async function approveDeliver(orderId: string): Promise<void> {
   const user = await db
     .select()
     .from(users)
-    .where(eq(users.id, changedOrder[0].userId));
+    .where(eq(users.id, changedOrder[0].user));
 
-  const message = `Заказ ${changedOrder[0].id} %0AПользователя ${user[0].name} ${user[0]?.lastName} доставлен %0AПочта: ${user[0].email} %0AНомер телефона: ${user[0]?.phone ? user[0].phone : "Не найдено"}`;
+  const message = `Заказ ${changedOrder[0].id} %0AПользователя ${user[0].firstName} ${user[0]?.lastName} доставлен %0AПочта: ${user[0].email} %0AНомер телефона: ${user[0]?.phone ? user[0].phone : "Не найдено"}`;
   await sendSalesMessageTelegram(message);
 }
 export async function deniedDeliver(orderId: string): Promise<void> {
   await db
     .update(orders)
-    .set({ status: "FAILED" })
+    .set({ status: "cancelled" })
     .where(eq(orders.id, orderId));
   const changedOrder = await db
     .select()
@@ -33,8 +33,8 @@ export async function deniedDeliver(orderId: string): Promise<void> {
   const user = await db
     .select()
     .from(users)
-    .where(eq(users.id, changedOrder[0].userId));
+    .where(eq(users.id, changedOrder[0].user));
 
-  const message = `!ЗАКАЗ НЕ ДОСТАВЛЕН! %0AЗаказ ${changedOrder[0].id} %0AПользователя ${user[0].name} ${user[0]?.lastName} не доставлен %0AПочта: ${user[0].email} %0AНомер телефона: ${user[0]?.phone ? user[0].phone : "Не найдено"} %0AСвяжитесь с пользователем для выяснение подробностей`;
+  const message = `!ЗАКАЗ НЕ ДОСТАВЛЕН! %0AЗаказ ${changedOrder[0].id} %0AПользователя ${user[0].firstName} ${user[0]?.lastName} не доставлен %0AПочта: ${user[0].email} %0AНомер телефона: ${user[0]?.phone ? user[0].phone : "Не найдено"} %0AСвяжитесь с пользователем для выяснение подробностей`;
   await sendSalesMessageTelegram(message);
 }

--- a/src/pages/cabinet/api/route.ts
+++ b/src/pages/cabinet/api/route.ts
@@ -1,6 +1,6 @@
 "use server";
 import { db } from "@/src/db";
-import { orderItems, orders, products } from "@/src/db/schema";
+import { order_item, orders, products } from "@/src/db/schema";
 import { eq, inArray } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -12,16 +12,16 @@ export async function GET(
   const userOrders = await db
     .select()
     .from(orders)
-    .where(eq(user.id, orders.userId));
+    .where(eq(user.id, orders.user));
 
   const ordersId = userOrders.map((order) => order.id);
 
   const orderItemsById = await db
     .select()
-    .from(orderItems)
-    .where(inArray(orderItems.orderId, ordersId));
+    .from(order_item)
+    .where(inArray(order_item.order, ordersId));
 
-  const orderItemsOnlyId = orderItemsById.map((items) => items.productId);
+  const orderItemsOnlyId = orderItemsById.map((items) => items.product);
   const cartItemsOnlyProducts = await db
     .select()
     .from(products)
@@ -29,10 +29,10 @@ export async function GET(
 
   const orderItemsFull = userOrders.map((item) => {
     const orderItemsWithProduct = orderItemsById
-      .filter((orderItem) => orderItem.orderId === item.id)
+      .filter((orderItem) => orderItem.order === item.id)
       .map((orderItem) => {
         const productByItem = cartItemsOnlyProducts.find(
-          (product) => product.id === orderItem.productId,
+          (product) => product.id === orderItem.product,
         );
         return {
           ...productByItem,
@@ -43,8 +43,8 @@ export async function GET(
 
     return {
       id: item.id,
-      total: item.total,
-      createdAt: item.createdAt,
+      total: item.price,
+      createdAt: item.createAt,
       status: item.status,
       orderItems: orderItemsWithProduct,
       orderTotal: orderItemsWithProduct.reduce(

--- a/src/pages/cart/api/change-cart/route.ts
+++ b/src/pages/cart/api/change-cart/route.ts
@@ -2,14 +2,14 @@
 import { NextResponse } from "next/server";
 import { db } from "@/src/db";
 import { eq } from "drizzle-orm";
-import { cartItems } from "@/src/db/schema";
+import { cart_item } from "@/src/db/schema";
 
 export async function POST(request: Request) {
   const [cartItemId, quantity] = await request.json();
 
   await db
-    .update(cartItems)
+    .update(cart_item)
     .set({ quantity: quantity })
-    .where(eq(cartItemId, cartItems.id));
+    .where(eq(cart_item.id, cartItemId));
   return NextResponse.json("success");
 }

--- a/src/pages/cart/api/delete-cart/route.ts
+++ b/src/pages/cart/api/delete-cart/route.ts
@@ -2,11 +2,11 @@
 import { NextResponse } from "next/server";
 import { db } from "@/src/db";
 import { eq } from "drizzle-orm";
-import { cartItems } from "@/src/db/schema";
+import { cart_item } from "@/src/db/schema";
 
 export async function POST(request: Request) {
   const cartItemId = await request.json();
 
-  await db.delete(cartItems).where(eq(cartItemId, cartItems.id));
+  await db.delete(cart_item).where(eq(cart_item.id, cartItemId));
   return NextResponse.json("success");
 }

--- a/src/pages/cart/api/get-card/route.ts
+++ b/src/pages/cart/api/get-card/route.ts
@@ -1,6 +1,6 @@
 "use server";
 import { db } from "@/src/db";
-import { cartItems, carts, products } from "@/src/db/schema";
+import { cart_item, products } from "@/src/db/schema";
 import { eq, inArray } from "drizzle-orm";
 import { NextResponse } from "next/server";
 
@@ -9,22 +9,18 @@ export async function GET(
   { params }: { params: { id: string } },
 ) {
   const user = await params;
-  const cartId = await db
-    .select({ id: carts.id })
-    .from(carts)
-    .where(eq(user.id, carts.userId));
   const cartItemsById = await db
     .select()
-    .from(cartItems)
-    .where(eq(cartId[0].id, cartItems.cartId));
-  const cartItemsOnlyId = cartItemsById.map((items) => items.productId);
+    .from(cart_item)
+    .where(eq(cart_item.cart, user.id));
+  const cartItemsOnlyId = cartItemsById.map((items) => items.product);
   const cartItemsOnlyProducts = await db
     .select()
     .from(products)
     .where(inArray(products.id, cartItemsOnlyId));
   const cartItemsFull = cartItemsById.map((item) => {
     const productItem = cartItemsOnlyProducts.find(
-      (product) => product.id == item.productId,
+      (product) => product.id == item.product,
     );
     return {
       orderItem: item,

--- a/src/pages/cart/api/set-order/route.ts
+++ b/src/pages/cart/api/set-order/route.ts
@@ -2,13 +2,7 @@
 import { NextResponse } from "next/server";
 import { db } from "@/src/db";
 import { eq, inArray } from "drizzle-orm";
-import {
-  cartItems,
-  orderItems,
-  orders,
-  products,
-  users,
-} from "@/src/db/schema";
+import { cart_item, order_item, orders, products, users } from "@/src/db/schema";
 import { v4 as uuidv4 } from "uuid";
 import { sendSalesMessageTelegram } from "@/src/shared/api/telegram/telegram-sales";
 
@@ -22,25 +16,25 @@ export async function POST(request: Request) {
 
   const cartItemsQuantity = await db
     .select({
-      productId: cartItems.productId,
-      quantity: cartItems.quantity,
+      product: cart_item.product,
+      quantity: cart_item.quantity,
     })
-    .from(cartItems)
-    .where(inArray(cartItems.id, cartItemsId));
+    .from(cart_item)
+    .where(inArray(cart_item.id, cartItemsId));
 
   const orderId = uuidv4();
   const orderInsertItems = cartItemsQuantity.map((item, index) => {
     return {
       id: uuidv4(),
-      orderId: orderId,
-      productId: item.productId,
+      order: orderId,
+      product: item.product,
       quantity: item.quantity,
       price: cartProuctsPrice[index].price,
     };
   });
 
-  await db.insert(orderItems).values(orderInsertItems);
-  await db.delete(cartItems).where(inArray(cartItems.id, cartItemsId));
+  await db.insert(order_item).values(orderInsertItems);
+  await db.delete(cart_item).where(inArray(cart_item.id, cartItemsId));
 
 
   const total = orderInsertItems.reduce(
@@ -50,19 +44,24 @@ export async function POST(request: Request) {
   const user = await db.select().from(users).where(eq(users.id, userId));
   await db.insert(orders).values({
     id: orderId,
-    userId: userId,
-    total: total,
-    status: "PROCESSED",
+    user: userId,
+    addresses: (user[0] as any)?.address,
+    price: total,
+    status: "pending",
+    pay_method: "card",
+    delivery: true,
   });
-  cartItemsQuantity.forEach(async (item) =>  {
+  cartItemsQuantity.forEach(async (item) => {
     const productItem = cartProuctsPrice.find(
-      (product) => product.id == item.productId,
+      (product) => product.id == item.product,
     );
 
-    await db.update(products).set({stock: productItem.stock - item.quantity}).where(eq(products.id, item.productId))
-
+    await db
+      .update(products)
+      .set({ stock: productItem!.stock - item.quantity })
+      .where(eq(products.id, item.product));
   });
-  const message = `Оформлен заказ ${orderId} %0AПользователя ${user[0].name} ${user[0]?.lastName} %0AАдресс ${user[0]?.address} %0AТоваров в заказе ${orderInsertItems.length} %0AСумма заказа ${total} %0AПочта: ${user[0].email} %0AНомер телефона: ${user[0]?.phone ? user[0].phone : "Не найдено"} %0AДля получения подробной информации зайдите в панель заказов`;
+  const message = `Оформлен заказ ${orderId} %0AПользователя ${user[0].firstName} ${user[0]?.lastName} %0AАдресс ${user[0]?.address} %0AТоваров в заказе ${orderInsertItems.length} %0AСумма заказа ${total} %0AПочта: ${user[0].email} %0AНомер телефона: ${user[0]?.phone ? user[0].phone : "Не найдено"} %0AДля получения подробной информации зайдите в панель заказов`;
   await sendSalesMessageTelegram(message);
   return NextResponse.json("success");
 }

--- a/src/pages/products-panel/api/product.tsx
+++ b/src/pages/products-panel/api/product.tsx
@@ -1,12 +1,15 @@
 'use server'
 import { db } from "@/src/db";
-import { orderItems, products } from "@/src/db/schema";
+import { order_item, products } from "@/src/db/schema";
 import { eq } from "drizzle-orm";
 
-export async function getProduct(id:string) {
-const product = await db.select().from(products).where(eq(products.id, id));
-const productSaled = await db.select().from(orderItems).where(eq(id, orderItems.productId));
-return [product[0], productSaled.length];
+export async function getProduct(id: string) {
+  const product = await db.select().from(products).where(eq(products.id, id));
+  const productSaled = await db
+    .select()
+    .from(order_item)
+    .where(eq(order_item.product, id));
+  return [product[0], productSaled.length];
 }
 export async function deleteProduct(id:string) {
   await db.delete(products).where(eq(products.id, id));

--- a/src/pages/register/api/route.ts
+++ b/src/pages/register/api/route.ts
@@ -2,11 +2,11 @@ import { NextResponse } from "next/server";
 import bcrypt from "bcryptjs";
 import { eq } from "drizzle-orm";
 import { db } from "@/src/db";
-import { carts, users } from "@/src/db/schema";
+import { users } from "@/src/db/schema";
 import { v4 as uuidv4 } from "uuid";
 
 export async function POST(request: Request) {
-  const { name, lastName, email, password } = await request.json();
+  const { firstName, lastName, email, password } = await request.json();
 
   try {
     // Check if email already exists
@@ -31,17 +31,13 @@ export async function POST(request: Request) {
       .insert(users)
       .values({
         id: id,
-        name,
+        firstName,
         lastName,
         email,
         password: hashedPassword,
-        role: "CLIENT", // Default role for new registrations
+        role: "user", // Default role for new registrations
       })
       .$returningId();
-    await db.insert(carts).values({
-      id: uuidv4(),
-      userId: id,
-    });
     const newUser = await db.select().from(users).where(eq(users.email, email));
 
     const { password: _, ...userWithoutPassword } = newUser[0];


### PR DESCRIPTION
## Summary
- adapt user registration to new user fields
- migrate cart and order routes to new cart_item/order_item tables
- update admin and cabinet endpoints to revised schema

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_b_68c742964f2083249e829f1142129cf0